### PR TITLE
Make go lint happy

### DIFF
--- a/kafka/build_static.go
+++ b/kafka/build_static.go
@@ -25,4 +25,4 @@ import "github.com/confluentinc/confluent-kafka-go-dev/kafka/librdkafka"
 
 // LibrdkafkaVersion is a numeric representation of the librdkafka version
 // linked statically with this build.
-var LibrdkafkaVersion int = librdkafka.LibrdkafkaVersion
+var LibrdkafkaVersion = librdkafka.LibrdkafkaVersion


### PR DESCRIPTION
```
$ if [[ -f .do_lint ]]; then golint -set_exit_status ./... ; fi
kafka/build_static.go:28:23: should omit type int from declaration of var LibrdkafkaVersion; it will be inferred from the right-hand side
Found 1 lint suggestions; failing.
The command "if [[ -f .do_lint ]]; then golint -set_exit_status ./... ; fi" exited with 1.
```